### PR TITLE
fix: Fixing bug where Strapi UI is crashing when no locale is found

### DIFF
--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -60,10 +60,21 @@ export default {
             };
           })
           .catch(() => {
-            return {
-              data: {},
-              locale,
-            };
+            return import(
+              /* webpackChunkName: "config-sync-translation-[request]" */ `./translations/en.json`
+            )
+              .then(({ default: data }) => {
+                return {
+                  data: prefixPluginTranslations(data, pluginId),
+                  locale,
+                };
+              })
+              .catch(() => {
+                return {
+                  data: {},
+                  locale,
+                };
+              });
           });
       }),
     );

--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -49,33 +49,20 @@ export default {
   bootstrap(app) {},
   async registerTrads({ locales }) {
     const importedTrads = await Promise.all(
-      locales.map((locale) => {
-        return import(
-          /* webpackChunkName: "config-sync-translation-[request]" */ `./translations/${locale}.json`
-        )
-          .then(({ default: data }) => {
-            return {
-              data: prefixPluginTranslations(data, pluginId),
-              locale,
-            };
-          })
-          .catch(() => {
-            return import(
-              /* webpackChunkName: "config-sync-translation-[request]" */ `./translations/en.json`
-            )
-              .then(({ default: data }) => {
-                return {
-                  data: prefixPluginTranslations(data, pluginId),
-                  locale,
-                };
-              })
-              .catch(() => {
-                return {
-                  data: {},
-                  locale,
-                };
-              });
-          });
+      locales.map(async (locale) => {
+        try {
+          // eslint-disable-next-line import/no-dynamic-require
+          const data = require(`./translations/${locale}.json`);
+          return {
+            data: prefixPluginTranslations(data, pluginId),
+            locale,
+          };
+        } catch {
+          return {
+            data: {},
+            locale,
+          };
+        }
       }),
     );
 

--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -51,7 +51,7 @@ export default {
     const importedTrads = await Promise.all(
       locales.map(async (locale) => {
         try {
-          // eslint-disable-next-line import/no-dynamic-require
+          // eslint-disable-next-line import/no-dynamic-require, global-require
           const data = require(`./translations/${locale}.json`);
           return {
             data: prefixPluginTranslations(data, pluginId),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Adding a try-catch if unable to load correct translations - will now fallback to english.

### Why is it needed?

I have swedish locale 'sv' in my Strapi app, but it makes the app crash since it is not translated in the plugin

### How to test it?

Change locale to 'sv' or another missing translation, it should load 'en' translations

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
