### PR TITLE
feat: use adm-zip instead of 'zip' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@strapi/design-system": "2.0.0-rc.11",
     "@strapi/icons": "2.0.0-rc.11",
     "@strapi/utils": "5.2.0",
+    "adm-zip": "^0.5.16",
     "chalk": "^4.1.2",
     "cli-table": "^0.3.6",
     "commander": "^8.3.0",

--- a/server/services/main.js
+++ b/server/services/main.js
@@ -3,7 +3,8 @@
 import isEmpty from 'lodash/isEmpty';
 import fs from 'fs';
 import util from 'util';
-import childProcess from "child_process";
+import AdmZip from 'adm-zip';
+
 import difference from '../utils/getObjectDiff';
 import { logMessage } from '../utils';
 
@@ -73,13 +74,12 @@ export default () => ({
    * @returns {void}
    */
   zipConfigFiles: async () => {
-    const fileName = `config-${new Date().toJSON()}.zip`;
-    childProcess.execSync(`zip -r ${fileName} *`, {
-      cwd: strapi.config.get('plugin.config-sync.syncDir'),
-    });
-    const fullFilePath = `${strapi.config.get('plugin.config-sync.syncDir')}${fileName}`;
-    const base64Data = fs.readFileSync(fullFilePath, { encoding: 'base64' });
-    fs.unlinkSync(fullFilePath);
+    const fileName = `config-sync-${new Date().toJSON()}.zip`;
+
+    const zip = new AdmZip();
+    zip.addLocalFolder(strapi.config.get('plugin.config-sync.syncDir'));
+    const base64Data = zip.toBuffer().toString('base64');
+
     return { base64Data, name: fileName, message: 'Success' };
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3913,6 +3913,11 @@ addressparser@1.0.1:
   resolved "https://registry.yarnpkg.com/addressparser/-/addressparser-1.0.1.tgz#47afbe1a2a9262191db6838e4fd1d39b40821746"
   integrity sha512-aQX7AISOMM7HFE0iZ3+YnD07oIeJqWGVnJ+ZIKaBZAk03ftmVYVqsGas/rbXKR21n4D/hKCSHypvcyOkds/xzg==
 
+adm-zip@^0.5.16:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.16.tgz#0b5e4c779f07dedea5805cdccb1147071d94a909"
+  integrity sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==
+
 aggregate-error@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Use `adm-zip` npm package, instead of the `zip` command, to zip the config/sync dir.

### Why is it needed?

As the `zip` command might not be available in the users env.

### Related issue(s)/PR(s)

#156 
