### PR TITLE
feat: add option to only include listed types and config

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -2,6 +2,7 @@
 
 import fs from 'fs';
 
+import { isEmpty } from 'lodash';
 import ConfigType from './config/type';
 import defaultTypes from './config/types';
 import { logMessage } from './utils';
@@ -23,21 +24,27 @@ export default async () => {
 
     // The default types provided by the plugin.
     defaultTypes(strapi).map((type) => {
-      if (!strapi.config.get('plugin::config-sync.excludedTypes').includes(type.configName)) {
+      const shouldInclude = isEmpty(strapi.config.get('plugin::config-sync.includedTypes')) || strapi.config.get('plugin::config-sync.includedTypes').includes(type.configName);
+      const shouldExclude = strapi.config.get('plugin::config-sync.excludedTypes').includes(type.configName);
+      if (shouldInclude && !shouldExclude) {
         types[type.configName] = new ConfigType(type);
       }
     });
 
     // The types provided by other plugins.
     strapi.plugin('config-sync').pluginTypes.map((type) => {
-      if (!strapi.config.get('plugin::config-sync.excludedTypes').includes(type.configName)) {
+      const shouldInclude = isEmpty(strapi.config.get('plugin::config-sync.includedTypes')) || strapi.config.get('plugin::config-sync.includedTypes').includes(type.configName);
+      const shouldExclude = strapi.config.get('plugin::config-sync.excludedTypes').includes(type.configName);
+      if (shouldInclude && !shouldExclude) {
         types[type.configName] = new ConfigType(type);
       }
     });
 
     // The custom types provided by the user.
     strapi.config.get('plugin::config-sync.customTypes').map((type) => {
-      if (!strapi.config.get('plugin::config-sync.excludedTypes').includes(type.configName)) {
+      const shouldInclude = isEmpty(strapi.config.get('plugin::config-sync.includedTypes')) || strapi.config.get('plugin::config-sync.includedTypes').includes(type.configName);
+      const shouldExclude = strapi.config.get('plugin::config-sync.excludedTypes').includes(type.configName);
+      if (shouldInclude && !shouldExclude) {
         types[type.configName] = new ConfigType(type);
       }
     });

--- a/server/config.js
+++ b/server/config.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 export default {
   default: {
@@ -7,7 +7,9 @@ export default {
     soft: false,
     importOnBootstrap: false,
     customTypes: [],
+    includedTypes: [],
     excludedTypes: [],
+    includedConfig: [],
     excludedConfig: [
       "core-store.plugin_users-permissions_grant",
       "core-store.plugin_upload_metrics",

--- a/server/services/main.js
+++ b/server/services/main.js
@@ -22,7 +22,7 @@ export default () => ({
    * @returns {void}
    */
   writeConfigFile: async (configType, configName, fileContents) => {
-    // Check if the config should be excluded.
+    // Check if the config should be included.
     const shouldInclude = isEmpty(strapi.config.get('plugin::config-sync.includedConfig')) || !isEmpty(strapi.config.get('plugin::config-sync.includedConfig').filter((option) => `${configType}.${configName}`.startsWith(option)));
     const shouldExclude = !isEmpty(strapi.config.get('plugin::config-sync.excludedConfig').filter((option) => `${configType}.${configName}`.startsWith(option)));
     if (!shouldInclude || shouldExclude) return;
@@ -58,7 +58,7 @@ export default () => ({
    * @returns {void}
    */
   deleteConfigFile: async (configName) => {
-    // Check if the config should be excluded.
+    // Check if the config should be included.
     const shouldInclude = isEmpty(strapi.config.get('plugin::config-sync.includedConfig')) || !isEmpty(strapi.config.get('plugin::config-sync.includedConfig').filter((option) => configName.startsWith(option)));
     const shouldExclude = !isEmpty(strapi.config.get('plugin::config-sync.excludedConfig').filter((option) => configName.startsWith(option)));
     if (!shouldInclude || shouldExclude) return;
@@ -242,7 +242,7 @@ export default () => ({
    * @returns {void}
    */
   importSingleConfig: async (configName, onSuccess, force) => {
-    // Check if the config should be excluded.
+    // Check if the config should be included.
     const shouldInclude = isEmpty(strapi.config.get('plugin::config-sync.includedConfig')) || !isEmpty(strapi.config.get('plugin::config-sync.includedConfig').filter((option) => configName.startsWith(option)));
     const shouldExclude = !isEmpty(strapi.config.get('plugin::config-sync.excludedConfig').filter((option) => configName.startsWith(option)));
     if (!shouldInclude || shouldExclude) return;
@@ -269,7 +269,7 @@ export default () => ({
    */
    exportSingleConfig: async (configName, onSuccess) => {
     console.log(configName);
-    // Check if the config should be excluded.
+    // Check if the config should be included.
     const shouldInclude = isEmpty(strapi.config.get('plugin::config-sync.includedConfig')) || !isEmpty(strapi.config.get('plugin::config-sync.includedConfig').filter((option) => configName.startsWith(option)));
     const shouldExclude = !isEmpty(strapi.config.get('plugin::config-sync.excludedConfig').filter((option) => configName.startsWith(option)));
     if (!shouldInclude || shouldExclude) return;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

- Add additional config to the plugin to support including only certain types (`includeTypes`) and certain config (`includeConfig`)
- The behaviour of these options is as follows:
  - If the included lists are empty: All types/config are synced
  - If the included list has items: Only the types/config in the list are synced
  - If the included and excluded lists both have items: Only the types in included which are not in excluded are synced (i.e., excluded lists take priority).

### Why is it needed?

I only want the plugin to sync certain types of config.

### How to test it?

Follow the steps to build the playground environment. Provide config options for `includeTypes` or `includeConfig`. Run an export. Only the provided items will be exported.

### Related issue(s)/PR(s)

- Created in response to: https://github.com/pluginpal/strapi-plugin-config-sync/issues/96
