### PR TITLE
Documentation typo, fixing broken link

### DIFF
--- a/docs/docs/getting-started/admin-gui.md
+++ b/docs/docs/getting-started/admin-gui.md
@@ -10,4 +10,4 @@ This plugin ships with a React app which can be accessed from the settings page 
 **Pro tip:**
 By clicking on one of the items in the diff table you can see the exact difference between sync dir and database in a git-style diff viewer.
 
-<img src="/img/assets/admin-diff-viewer.png" alt="Config diff in admin" />
+![Config diff in admin](/img/assets/admin-diff-viewer.png)

--- a/docs/docs/getting-started/motivation.md
+++ b/docs/docs/getting-started/motivation.md
@@ -6,7 +6,7 @@ slug: /motivation
 
 # 💡 Motivation
 
-In Strapi we come across what I would call config types. These are models of which the records are stored in our database, just like content types. Though the big difference here is that your code ofter relies on the database records of these types. 
+In Strapi we come across what I would call config types. These are models of which the records are stored in our database, just like content types. Though the big difference here is that your code often relies on the database records of these types. 
 
 Having said that, it makes sense that these records can be exported, added to git, and be migrated across environments. This way we can make sure we have all the data our code relies on, on each environment.
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Fixes a typo and a broken link in the documentation.

### Why is it needed?

Was reading the docs, felt like I could help fix them up!

### How to test it?

The current image link is broken and this change should fix the page once built/published: https://docs.pluginpal.io/config-sync/admin-gui

Docusaurus docs suggest the current state <img..> tags in .md files won't do the trick https://docusaurus.io/docs/static-assets#in-markdown

### Related issue(s)/PR(s)

n/a
